### PR TITLE
Fix example for ipad

### DIFF
--- a/Example/ANDLineChartViewExample/ANDLineChartView-Info.plist
+++ b/Example/ANDLineChartViewExample/ANDLineChartView-Info.plist
@@ -24,8 +24,6 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>UIMainStoryboardFile~ipad</key>
-	<string>Main_iPad</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
Running the example on a iPad simulator the app crashes with the following error:

```
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Could not find a storyboard named 'Main_iPad'
```

Removing the ipad storyboard from the *-Info.plist fixes this.
